### PR TITLE
bump zendesk_api gem to '1.0.2'

### DIFF
--- a/gds_zendesk.gemspec
+++ b/gds_zendesk.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'null_logger', '0.0.1'
-  gem.add_dependency 'zendesk_api', '1.0.1'
+  gem.add_dependency 'zendesk_api', '1.0.2'
 
   gem.add_development_dependency 'rake', '10.0.3'
   gem.add_development_dependency 'rspec', '2.12.0'


### PR DESCRIPTION
this improves the logging for RecordInvalid exceptions
