### PR TITLE
Bump version to 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 1.0.3
+
+* Update the `zendesk_api` library to the latest version (1.5.1)

--- a/lib/gds_zendesk/version.rb
+++ b/lib/gds_zendesk/version.rb
@@ -1,3 +1,3 @@
 module GDSZendesk
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
This picks up the 'zendesk_api' version bump.
