### PR TITLE
Bump zendesk_api gem to 1.6.3

### DIFF
--- a/gds_zendesk.gemspec
+++ b/gds_zendesk.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'null_logger', '0.0.1'
-  gem.add_dependency 'zendesk_api', '1.5.1'
+  gem.add_dependency 'zendesk_api', '1.6.3'
 
   gem.add_development_dependency 'rake', '10.0.3'
   gem.add_development_dependency 'rspec', '3.1.0'


### PR DESCRIPTION
This upgrade:
- fixes this error in the Support app (https://errbit.preview.alphagov.co.uk/apps/5319f4d40da115d7a90004fe/problems/5526b2990da1157bfa0008be)
- is done in order to avoid falling too far behind the latest.