### PR TITLE
Bump version to 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.4
+
+* Update the `zendesk_api` library to the v1.6.3 (to keep up to date)
+
 # 1.0.3
 
 * Update the `zendesk_api` library to the latest version (1.5.1)

--- a/lib/gds_zendesk/version.rb
+++ b/lib/gds_zendesk/version.rb
@@ -1,3 +1,3 @@
 module GDSZendesk
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end


### PR DESCRIPTION
This includes the 'zendesk_api' dependency bump.

/cc @issyl0 