### PR TITLE
Ticket creation should fail when the API returns a redirect

### DIFF
--- a/gds_zendesk.gemspec
+++ b/gds_zendesk.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'null_logger', '0.0.1'
-  gem.add_dependency 'zendesk_api', '1.6.3'
+  gem.add_dependency 'zendesk_api', '1.8.0'
 
   gem.add_development_dependency 'rake', '10.0.3'
   gem.add_development_dependency 'rspec', '3.1.0'

--- a/spec/gds_zendesk/client_spec.rb
+++ b/spec/gds_zendesk/client_spec.rb
@@ -43,5 +43,13 @@ module GDSZendesk
 
       expect(post_stub).to have_been_requested
     end
+
+    it "raises an exception if the ticket creation wasn't successful" do
+      self.valid_zendesk_credentials = valid_credentials
+      post_stub = stub_http_request(:post, "#{zendesk_endpoint}/tickets").to_return(status: 302)
+
+      expect { client.ticket.create!(some: "data") }.to raise_error
+      expect(post_stub).to have_been_requested
+    end
   end
 end


### PR DESCRIPTION
This is a fix that has been made in the Zendesk API client gem v1.8.0.
(see https://github.com/zendesk/zendesk_api_client_rb/pull/236 for details)