### PR TITLE
Bump gem version to 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+# 1.0.5
+
+* Update the `zendesk_api` library to v1.8.0 (this picks up a bugfix for
+ticket creation succeeding when the API returns a redirect - see
+https://github.com/zendesk/zendesk_api_client_rb/pull/236)
+
 # 1.0.4
 
-* Update the `zendesk_api` library to the v1.6.3 (to keep up to date)
+* Update the `zendesk_api` library to v1.6.3 (to keep up to date)
 
 # 1.0.3
 

--- a/lib/gds_zendesk/version.rb
+++ b/lib/gds_zendesk/version.rb
@@ -1,3 +1,3 @@
 module GDSZendesk
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end


### PR DESCRIPTION
This picks up zendesk_api gem v1.8.0 (which contains a bugfix
for redirects being seen as valid responses during ticket submission).