### PR TITLE
Remove now-redundant field mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.0 (unreleased)
+
+* Removed: GDSZendesk::FIELD_MAPPINGS.
+
 # 1.0.5
 
 * Update the `zendesk_api` library to v1.8.0 (this picks up a bugfix for

--- a/lib/gds_zendesk/dummy_client.rb
+++ b/lib/gds_zendesk/dummy_client.rb
@@ -1,5 +1,4 @@
 require 'null_logger'
-require 'gds_zendesk/field_mappings'
 require 'zendesk_api/error'
 
 module GDSZendesk

--- a/lib/gds_zendesk/field_mappings.rb
+++ b/lib/gds_zendesk/field_mappings.rb
@@ -1,6 +1,0 @@
-module GDSZendesk
-  FIELD_MAPPINGS = {
-    needed_by_date:  "21485833",
-    not_before_date: "21502036"
-  }
-end


### PR DESCRIPTION
We have now moved the data we were putting into these custom fields into the
comment body in the support app, so we don't need these any longer.