### PR TITLE
Fix the dummy Zendesk client to be like real one

### DIFF
--- a/lib/gds_zendesk/dummy_client.rb
+++ b/lib/gds_zendesk/dummy_client.rb
@@ -56,9 +56,8 @@ module GDSZendesk
       false
     end
 
-    def create!(new_user_attributes)
-      @created_user_attributes = new_user_attributes
-      @logger.info("Zendesk user created: #{new_user_attributes.inspect}")
+    def create_or_update_user(new_attributes)
+      @logger.info("Zendesk user created or updated: #{new_attributes.inspect}")
     end
   end
 end

--- a/spec/gds_zendesk/dummy_client_spec.rb
+++ b/spec/gds_zendesk/dummy_client_spec.rb
@@ -29,14 +29,14 @@ module GDSZendesk
     end
 
     context "when a user has been created" do
-      let(:created_user_options) { { email: "a@b.com" } }
+      let(:options) { { email: "a@b.com" } }
 
       it "should log the user details" do
         logger = double("logger")
-        expect(logger).to receive(:info).with("Zendesk user created: #{created_user_options.inspect}")
+        expect(logger).to receive(:info).with("Zendesk user created or updated: #{options.inspect}")
 
         client = DummyClient.new(logger: logger)
-        client.users.create!(created_user_options)
+        client.users.create_or_update_user(options)
       end
     end
   end


### PR DESCRIPTION
The dummy Users class needed a `create_or_update_user` method, otherwise
the "Create or update user" request form in the Support app didn't
work correctly in development mode.

/cc @binaryberry 