### PR TITLE
Add zendesk_returns_conflict test helper

### DIFF
--- a/lib/gds_zendesk/test_helpers.rb
+++ b/lib/gds_zendesk/test_helpers.rb
@@ -46,6 +46,10 @@ module GDSZendesk
       stub_request(:any, /#{zendesk_endpoint}\/.*/).to_return(status: 503)
     end
 
+    def zendesk_returns_conflict
+      stub_request(:any, /#{zendesk_endpoint}\/.*/).to_return(status: 409)
+    end
+
     def zendesk_endpoint
       "https://#{valid_zendesk_credentials["username"]}:#{valid_zendesk_credentials["password"]}@govuk.zendesk.com/api/v2"
     end


### PR DESCRIPTION
This is needed to work on the support app bug that means duplicates are created
when Zendesk is returning a 409.