### PR TITLE
Allow the URL to be configured

### DIFF
--- a/lib/gds_zendesk/client.rb
+++ b/lib/gds_zendesk/client.rb
@@ -24,7 +24,7 @@ module GDSZendesk
       check_that_username_and_password_are_provided
 
       ZendeskAPI::Client.new { |config|
-        config.url = "https://govuk.zendesk.com/api/v2/"
+        config.url = url
         config.username = username
         config.password = password
         config.logger = logger
@@ -49,8 +49,15 @@ module GDSZendesk
       @config_options[:password] || @config_options["password"]
     end
 
+    def url
+      @config_options[:url] || @config_options["url"]
+    end
+
     def defaults
-      { logger: NullLogger.instance }
+      {
+          logger: NullLogger.instance,
+          url: "https://govuk.zendesk.com/api/v2/"
+      }
     end
   end
 end

--- a/spec/gds_zendesk/client_spec.rb
+++ b/spec/gds_zendesk/client_spec.rb
@@ -35,6 +35,14 @@ module GDSZendesk
       expect(client(logger: custom_logger).config_options[:logger]).to eq(custom_logger)
     end
 
+    it "should use the default url if no url is provided" do
+      expect(client.config_options[:url]).to eq "https://govuk.zendesk.com/api/v2/"
+    end
+
+    it "should use the configured url if provided" do
+      expect(Client.new(username: "test_user", password: "test_pass", url: "https://example.com").config_options[:url]).to eq "https://example.com"
+    end
+
     it "should raise tickets in Zendesk" do
       self.valid_zendesk_credentials = valid_credentials
       post_stub = stub_zendesk_ticket_creation(some: "data")


### PR DESCRIPTION
If someone outside GOV.UK were to use this, the URL would need to be
configurable.

With :purple_heart: from @yolinas and @richardtowers