### PR TITLE
Make the gemspec requirements more flexible

### DIFF
--- a/gds_zendesk.gemspec
+++ b/gds_zendesk.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'null_logger', '0.0.1'
-  gem.add_dependency 'zendesk_api', '1.14.4'
+  gem.add_dependency 'null_logger', '~> 0'
+  gem.add_dependency 'zendesk_api', '~> 1.14'
 
-  gem.add_development_dependency 'rake', '10.0.3'
-  gem.add_development_dependency 'rspec', '3.1.0'
-  gem.add_development_dependency "webmock", '~> 2.3.0'
+  gem.add_development_dependency 'rake', '~> 10'
+  gem.add_development_dependency 'rspec', '~> 3'
+  gem.add_development_dependency 'webmock', '~> 2'
 end


### PR DESCRIPTION
Specify loose dependencies on either the minor or major versions of
the gems. The exact version will be set in the relevant Gemfile.lock
files, or elsewhere.