### PR TITLE
Update zendesk_api dependency to v1.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Update `zendesk_api` library to v1.27
+
 # 3.0.0
 
 * Update the `webmock` library to version v2.3.2 to be compatible with Ruby

--- a/gds_zendesk.gemspec
+++ b/gds_zendesk.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'null_logger', '~> 0'
-  gem.add_dependency 'zendesk_api', '~> 1.14'
+  gem.add_dependency 'zendesk_api', '~> 1.27'
 
   gem.add_development_dependency 'rake', '~> 10'
   gem.add_development_dependency 'rspec', '~> 3'


### PR DESCRIPTION
This updates the dependency for the `zendesk_api` gem to v1.27.

Leaving on v1.14 was causing issues for newer applications, where we already have other dependencies using `faraday >= 1.0`, whilst the older release of `zendesk_api` was requiring `faraday ~> 0.9`.  Updating this gem removes this conflict.

Zendesk ticket: https://trello.com/c/6YrNw89o/285-add-a-contact-form-to-the-account-manager