### PR TITLE
Allow use of a token instead of password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Allow use of a token instead of password
+
 # 3.1.0
 
 * Update `zendesk_api` library to v1.27

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This generates an initializer at `config/initializers/gds_zendesk.rb`.
 
 #### Mandatory settings
 
-This gem needs to be configured with a Zendesk username and password before it can be used.
+This gem needs to be configured with a Zendesk username and password (or token)  before it can be used.
 These are set in `config/initializers/gds_zendesk.rb`
 
 #### Enabling development mode

--- a/lib/gds_zendesk/client.rb
+++ b/lib/gds_zendesk/client.rb
@@ -26,7 +26,8 @@ module GDSZendesk
       ZendeskAPI::Client.new { |config|
         config.url = url
         config.username = username
-        config.password = password
+        config.token = token if token
+        config.password = password if password
         config.logger = logger
       }
     end
@@ -38,11 +39,16 @@ module GDSZendesk
 
     def check_that_username_and_password_are_provided
       raise ArgumentError, "Zendesk username not provided" if username.nil?
-      raise ArgumentError, "Zendesk password not provided" if password.nil?
+      raise ArgumentError, "Zendesk password or token not provided" if password.nil? && token.nil?
+      raise ArgumentError, "Provide only one of token or password" unless password.nil? || token.nil?
     end
 
     def username
       @config_options[:username] || @config_options["username"]
+    end
+
+    def token
+      @config_options[:token] || @config_options["token"]
     end
 
     def password

--- a/lib/generators/gds_zendesk/install/install_generator.rb
+++ b/lib/generators/gds_zendesk/install/install_generator.rb
@@ -8,7 +8,7 @@ GDS_ZENDESK_CLIENT = if Rails.env.development? || Rails.env.test?
 else
   config_yaml_file = File.join(Rails.root, 'config', 'zendesk.yml')
   config = YAML.load_file(config_yaml_file)[Rails.env]
-  GDSZendesk::Client.new(username: config['username'], password: config['password'], logger: Rails.logger)
+  GDSZendesk::Client.new(username: config['username'], password: config['password'], token: config['token'], logger: Rails.logger)
 end
 END
 

--- a/spec/gds_zendesk/client_spec.rb
+++ b/spec/gds_zendesk/client_spec.rb
@@ -20,9 +20,24 @@ module GDSZendesk
         /username not provided/)
     end
 
-    it "should raise an error if no password is provided" do
+    it "should raise an error if no password or token is provided" do
       expect { Client.new(username: "abc") }.to raise_error(ArgumentError,
-        /password not provided/)
+        /password or token not provided/)
+    end
+
+    it "should raise an error if token and password are provided" do
+      expect { Client.new(username: "abc", token: "def", password: "ghi") }.to raise_error(ArgumentError,
+        /Provide only one of token or password/)
+    end
+
+    it "should not raise an error if token is provided without password" do
+      expect { Client.new(username: "abc", token: "def") }.not_to raise_error(ArgumentError,
+        /password or token not provided/)
+    end
+
+    it "should not raise an error if password is provided without token" do
+      expect { Client.new(username: "abc", password: "def") }.not_to raise_error(ArgumentError,
+        /password or token not provided/)
     end
 
     it "should use a null logger if no logger has been provided" do
@@ -37,6 +52,14 @@ module GDSZendesk
 
     it "should use the default url if no url is provided" do
       expect(client.config_options[:url]).to eq "https://govuk.zendesk.com/api/v2/"
+    end
+
+    it "should use the token if provided" do
+      expect(Client.new(username: "test_user", token: "test_token").config_options[:token]).to eq "test_token"
+    end
+
+    it "should use the password if provided" do
+      expect(Client.new(username: "test_user", password: "test_password").config_options[:password]).to eq "test_password"
     end
 
     it "should use the configured url if provided" do


### PR DESCRIPTION
Zendesk allows us to use either a password or token for API users (see https://github.com/zendesk/zendesk_api_client_rb/blob/633c9022be26bf470b227f74c9a672ff010230fd/README.md#L68-69).  Therefore adding the ability for us to specify a token when using this gem.

Trello card: https://trello.com/c/6YrNw89o