### PR TITLE
Bump gem version to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 3.2.0
 
 * Allow use of a token instead of password
 

--- a/lib/gds_zendesk/version.rb
+++ b/lib/gds_zendesk/version.rb
@@ -1,3 +1,3 @@
 module GDSZendesk
-  VERSION = "3.1.0"
+  VERSION = "3.2.0"
 end


### PR DESCRIPTION
Increasing the version to release the feature allowing us of a API token instead of password.

Trello card: https://trello.com/c/6YrNw89o