### PR TITLE
Add access to Zendesk::Client object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 3.3.0
 
 * Allow access to Zendesk::Client from GDSZendesk::Client
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Allow access to Zendesk::Client from GDSZendesk::Client
+
 # 3.2.0
 
 * Allow use of a token instead of password

--- a/lib/gds_zendesk/client.rb
+++ b/lib/gds_zendesk/client.rb
@@ -10,6 +10,7 @@ module GDSZendesk
     def_delegators :@zendesk_client, :ticket
 
     attr_accessor :config_options
+    attr_reader :zendesk_client
 
     def initialize(config_options)
       @config_options = defaults.merge(config_options)

--- a/lib/gds_zendesk/version.rb
+++ b/lib/gds_zendesk/version.rb
@@ -1,3 +1,3 @@
 module GDSZendesk
-  VERSION = "3.2.0".freeze
+  VERSION = "3.3.0".freeze
 end


### PR DESCRIPTION
This allows applications to access and use Zendesk::Client object. Previously the Zendesk::Client could only be accessed via the `ticket` delegated method. This now references a private `ticket` method within `Zendesk::Client` and should be deprecated. Having access to the Zendesk::Client object also allows access to other API functions not supported by this wrapper gem.

Currently:
```ruby
gds_zendesk_client = GDSZendesk::Client.new(...)
gds_zendesk_client.ticket.create!(...)
```
```bash
warning: GDSZendesk::Client#ticket at .../forwardable.rb:154 forwarding to private method ZendeskAPI::Client#ticket
```

Now:
```ruby
zendesk_client = GDSZendesk::Client.new(...).zendesk_client
zendesk_client.tickets.create!(...)
```
