### PR TITLE
Fix licence typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,6 @@ To run the tests, use the follow:
 ```
 bundle exec rake default
 ```
-# Licence
+# Licence
 
 [MIT License](LICENCE)


### PR DESCRIPTION
This fixes the rendering which is currently broken on the README