### PR TITLE
Remove requirement for job and phone when creating or updating user

### DIFF
--- a/lib/gds_zendesk/users.rb
+++ b/lib/gds_zendesk/users.rb
@@ -31,11 +31,7 @@ module GDSZendesk
     end
 
     def create(requested_user)
-      attributes = {
-        email: requested_user.email,
-        name: requested_user.name,
-        verified: true,
-      }
+      attributes = { email: requested_user.email, name: requested_user.name, verified: true }
       attributes[:details] = "Job title: #{requested_user.job}" if requested_user.respond_to?(:job)
       attributes[:phone] = requested_user.phone if requested_user.respond_to?(:phone)
       @client.users.create!(attributes)

--- a/lib/gds_zendesk/users.rb
+++ b/lib/gds_zendesk/users.rb
@@ -31,17 +31,20 @@ module GDSZendesk
     end
 
     def create(requested_user)
-      @client.users.create!(
+      attributes = {
         email: requested_user.email,
         name: requested_user.name,
-        details: "Job title: #{requested_user.job}",
         phone: requested_user.phone,
         verified: true,
-      )
+      }
+      attributes[:details] = "Job title: #{requested_user.job}" if requested_user.respond_to?(:job)
+      @client.users.create!(attributes)
     end
 
     def update(existing_user_in_zendesk, requested_user)
-      existing_user_in_zendesk.update(details: "Job title: #{requested_user.job}")
+      attributes = {}
+      attributes[:details] = "Job title: #{requested_user.job}" if requested_user.respond_to?(:job)
+      existing_user_in_zendesk.update(attributes)
       if !requested_user.phone.nil? && !requested_user.phone.empty?
         existing_user_in_zendesk.update(phone: requested_user.phone)
       end

--- a/lib/gds_zendesk/users.rb
+++ b/lib/gds_zendesk/users.rb
@@ -44,10 +44,10 @@ module GDSZendesk
     def update(existing_user_in_zendesk, requested_user)
       attributes = {}
       attributes[:details] = "Job title: #{requested_user.job}" if requested_user.respond_to?(:job)
-      existing_user_in_zendesk.update(attributes)
       if !requested_user.phone.nil? && !requested_user.phone.empty?
-        existing_user_in_zendesk.update(phone: requested_user.phone)
+        attributes[:phone] = requested_user.phone
       end
+      existing_user_in_zendesk.update(attributes)
       existing_user_in_zendesk.save
       existing_user_in_zendesk
     end

--- a/lib/gds_zendesk/users.rb
+++ b/lib/gds_zendesk/users.rb
@@ -34,17 +34,17 @@ module GDSZendesk
       attributes = {
         email: requested_user.email,
         name: requested_user.name,
-        phone: requested_user.phone,
         verified: true,
       }
       attributes[:details] = "Job title: #{requested_user.job}" if requested_user.respond_to?(:job)
+      attributes[:phone] = requested_user.phone if requested_user.respond_to?(:phone)
       @client.users.create!(attributes)
     end
 
     def update(existing_user_in_zendesk, requested_user)
       attributes = {}
       attributes[:details] = "Job title: #{requested_user.job}" if requested_user.respond_to?(:job)
-      if !requested_user.phone.nil? && !requested_user.phone.empty?
+      if requested_user.respond_to?(:phone) && !requested_user.phone.nil? && !requested_user.phone.empty?
         attributes[:phone] = requested_user.phone
       end
       existing_user_in_zendesk.update(attributes)

--- a/lib/gds_zendesk/users.rb
+++ b/lib/gds_zendesk/users.rb
@@ -31,11 +31,13 @@ module GDSZendesk
     end
 
     def create(requested_user)
-      @client.users.create!(email: requested_user.email,
-                            name: requested_user.name,
-                            details: "Job title: #{requested_user.job}",
-                            phone: requested_user.phone,
-                            verified: true)
+      @client.users.create!(
+        email: requested_user.email,
+        name: requested_user.name,
+        details: "Job title: #{requested_user.job}",
+        phone: requested_user.phone,
+        verified: true,
+      )
     end
 
     def update(existing_user_in_zendesk, requested_user)

--- a/spec/gds_zendesk/users_spec.rb
+++ b/spec/gds_zendesk/users_spec.rb
@@ -30,6 +30,16 @@ module GDSZendesk
     end
 
     context "when a user doesn't exist" do
+      let(:expected_attributes) do
+        {
+          verified: true,
+          name: "Abc",
+          email: "test@test.com",
+          phone: "12345",
+          details: "Job title: Developer",
+        }
+      end
+
       before do
         zendesk_has_no_user_with_email("test@test.com")
       end
@@ -39,13 +49,7 @@ module GDSZendesk
       end
 
       it "can create that user" do
-        stub_post = stub_zendesk_user_creation(
-          verified: true,
-          name: "Abc",
-          email: "test@test.com",
-          phone: "12345",
-          details: "Job title: Developer",
-        )
+        stub_post = stub_zendesk_user_creation(expected_attributes)
         user_being_requested = double("requested user", {
           name: "Abc", email: "test@test.com", phone: "12345", job: "Developer"
         })

--- a/spec/gds_zendesk/users_spec.rb
+++ b/spec/gds_zendesk/users_spec.rb
@@ -30,6 +30,13 @@ module GDSZendesk
         expect(stub_post).to have_been_requested
       end
 
+      it "can update a user which doesn't respond to #phone" do
+        stub_post = stub_zendesk_user_update(123, details: "Job title: Developer")
+        users.create_or_update_user(double("requested user", email: "test@test.com", job: "Developer"))
+
+        expect(stub_post).to have_been_requested
+      end
+
       it "knows whether the user is suspended or not" do
         zendesk_has_user(email: "test@test.com", id: 123, suspended: "true")
         expect(users).to be_suspended("test@test.com")
@@ -69,6 +76,16 @@ module GDSZendesk
         stub_post = stub_zendesk_user_creation(expected_attributes.except(:details))
         user_being_requested = double("requested user", {
           name: "Abc", email: "test@test.com", phone: "12345"
+        })
+
+        users.create_or_update_user(user_being_requested)
+        expect(stub_post).to have_been_requested
+      end
+
+      it "can create that user which doesn't respond to #phone" do
+        stub_post = stub_zendesk_user_creation(expected_attributes.except(:phone))
+        user_being_requested = double("requested user", {
+          name: "Abc", email: "test@test.com", job: "Developer"
         })
 
         users.create_or_update_user(user_being_requested)

--- a/spec/gds_zendesk/users_spec.rb
+++ b/spec/gds_zendesk/users_spec.rb
@@ -23,6 +23,13 @@ module GDSZendesk
         expect(stub_post).to have_been_requested
       end
 
+      it "can update a user which doesn't respond to #job" do
+        stub_post = stub_zendesk_user_update(123, phone: "12345")
+        users.create_or_update_user(double("requested user", email: "test@test.com", phone: "12345"))
+
+        expect(stub_post).to have_been_requested
+      end
+
       it "knows whether the user is suspended or not" do
         zendesk_has_user(email: "test@test.com", id: 123, suspended: "true")
         expect(users).to be_suspended("test@test.com")
@@ -52,6 +59,16 @@ module GDSZendesk
         stub_post = stub_zendesk_user_creation(expected_attributes)
         user_being_requested = double("requested user", {
           name: "Abc", email: "test@test.com", phone: "12345", job: "Developer"
+        })
+
+        users.create_or_update_user(user_being_requested)
+        expect(stub_post).to have_been_requested
+      end
+
+      it "can create that user which doesn't respond to #job" do
+        stub_post = stub_zendesk_user_creation(expected_attributes.except(:details))
+        user_being_requested = double("requested user", {
+          name: "Abc", email: "test@test.com", phone: "12345"
         })
 
         users.create_or_update_user(user_being_requested)

--- a/spec/gds_zendesk/users_spec.rb
+++ b/spec/gds_zendesk/users_spec.rb
@@ -46,8 +46,9 @@ module GDSZendesk
           phone: "12345",
           details: "Job title: Developer",
         )
-        user_being_requested = double("requested user",
-                                      name: "Abc", email: "test@test.com", phone: "12345", job: "Developer")
+        user_being_requested = double("requested user", {
+          name: "Abc", email: "test@test.com", phone: "12345", job: "Developer"
+        })
 
         users.create_or_update_user(user_being_requested)
         expect(stub_post).to have_been_requested


### PR DESCRIPTION
Zendesk itself doesn't require the `details` or `phone` attributes to be set and, looking in the git history for both this repo and the Support app repo (where this code seems to have originated), I can't find any rationale for why the current code expects a job title and phone number to be provided.

The only [use of `Users#create_or_update_user`][1] seems to be in the Support app. And in [this pull request][2] we changed the relevant form so that it no longer collects the requested user's job title or phone number. So it seems to make sense to remove the requirement for the required user to respond to the `#job` and `#phone` methods.

[1]: https://github.com/search?q=org%3Aalphagov%20%22users.create_or_update_user%22&type=code
[2]: https://github.com/alphagov/support/pull/1244