### PR TITLE
Bump version from v3.5.0 -> v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.6.0
+
+* Don't require requested user object to respond to `#job` or `#phone` in calls to `Users#create_or_update_user`
+
 # 3.5.0
 
 * Add support for `zendesk_api` v3.x

--- a/lib/gds_zendesk/version.rb
+++ b/lib/gds_zendesk/version.rb
@@ -1,3 +1,3 @@
 module GDSZendesk
-  VERSION = "3.5.0".freeze
+  VERSION = "3.6.0".freeze
 end


### PR DESCRIPTION
The change to `Users#create_or_update_user` is backwardly compatible so I've made this a minor version bump.

It would be nice to start using this in the Support app, so we can simplify the code slightly.