### PR TITLE
Add retirement notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GDS Zendesk
 
+> This gem was archived. The functionality was ported to [Support API](https://github.com/alphagov/support-api). 
+
 ## What is it?
 
 `gds_zendesk` is a Ruby gem which (partially) wraps the [Zendesk REST API v2](http://developer.zendesk.com/documentation/rest_api/introduction.html).


### PR DESCRIPTION
This functionality was ported to Support API: /support-tickets endpoint [^1] is exposed via GDA API Adapters's [^2].

We want to consolidate onto one centralised way of raising support tickets. This will minimise the maintenance overhead if we ever switch away from Zendesk (rumoured to be happening in 2024) and will make the process more vendor agnostic.

https://github.com/alphagov/gds_zendesk/issues/108

[^1]: https://github.com/alphagov/support-api/blob/c0b6ca3587f6673c9512573deeecd66a2aaa0d98/app/controllers/support_tickets_controller.rb
[^2]: https://github.com/alphagov/gds-api-adapters/blob/9aabf9d/lib/gds_api/support_api.rb#L25-L39

